### PR TITLE
get xsrf_token from cookies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ author = "Brig Lamoreaux"
 # The short X.Y version
 version = "1.3"
 # The full version, including alpha/beta/rc tags
-release = "1.3.2"
+release = "1.3.3"
 # version = re.sub(r'(\d+\.\d+)\.\d+(.*)', r'\1\2', srpenergy.__version__)
 # version = re.sub(r'(\.dev\d+).*?$', r'\1', version)
 

--- a/srpenergy/__init__.py
+++ b/srpenergy/__init__.py
@@ -1,2 +1,2 @@
 """Init file for Srp Energy."""
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/srpenergy/client.py
+++ b/srpenergy/client.py
@@ -10,6 +10,8 @@ import re
 from dateutil.parser import parse
 import requests
 
+from urllib.parse import unquote
+
 BASE_USAGE_URL = "https://myaccount.srpnet.com/myaccountapi/api/"
 
 
@@ -277,8 +279,7 @@ class SrpEnergyClient:
                 )
 
                 response = session.get(BASE_USAGE_URL + "login/antiforgerytoken")
-                data = response.json()
-                xsrf_token = data["xsrfToken"]
+                xsrf_token = unquote(session.cookies["xsrf-token"])
 
                 response = session.get(
                     BASE_USAGE_URL
@@ -288,7 +289,7 @@ class SrpEnergyClient:
                     + str_startdate
                     + "&endDate="
                     + str_enddate,
-                    headers={"x-xsrf-token": xsrf_token},
+                    headers={"x-xsrf-token": xsrf_token}
                 )
 
                 data = response.json()

--- a/srpenergy/client.py
+++ b/srpenergy/client.py
@@ -279,7 +279,7 @@ class SrpEnergyClient:
                 )
 
                 response = session.get(BASE_USAGE_URL + "login/antiforgerytoken")
-                xsrf_token = unquote(session.cookies["xsrf-token"])
+                xsrf_token = unquote(response.cookies["xsrf-token"])
 
                 response = session.get(
                     BASE_USAGE_URL

--- a/srpenergy/client.py
+++ b/srpenergy/client.py
@@ -7,10 +7,10 @@ This module houses the main class used to fetch energy usage.
 from datetime import datetime, timedelta
 import re
 
+from urllib.parse import unquote
+
 from dateutil.parser import parse
 import requests
-
-from urllib.parse import unquote
 
 BASE_USAGE_URL = "https://myaccount.srpnet.com/myaccountapi/api/"
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -40,6 +40,7 @@ class MockResponse:
         """Return mock json."""
         return self.json_data
 
+
 def get_mock_requests(routes):
     """Return a function that can be mocked for the given routes."""
     # noqa: D202

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,8 +17,11 @@ MOCK_LOGIN_RESPONSE.json.return_value = {
 }
 
 MOCK_ANTI_FORGERY_RESPONSE = {
-    "message": "Success",
-    "xsrfToken": "CfDJ8KUcoIlbMHV_NbT4uDyb-XA2|207f",
+    "message": "Success"
+}
+
+MOCK_ANTI_FORGERY_RESPONSE_COOKIES = {
+    "xsrf-token": "CfDJ8KUcoIlbMHV_NbT4uDyb-XA2%7C207f"
 }
 
 
@@ -26,16 +29,16 @@ MOCK_ANTI_FORGERY_RESPONSE = {
 class MockResponse:
     """Mock Response."""
 
-    def __init__(self, json_data, status_code, kwargs):
+    def __init__(self, json_data, status_code, cookies, kwargs):
         """Create Mock Response."""
         self.json_data = json_data
         self.status_code = status_code
+        self.cookies = cookies
         self.kwargs = kwargs
 
     def json(self):
         """Return mock json."""
         return self.json_data
-
 
 def get_mock_requests(routes):
     """Return a function that can be mocked for the given routes."""
@@ -43,12 +46,12 @@ def get_mock_requests(routes):
     def mocked_requests_get(*args, **kwargs):
 
         if "login/antiforgerytoken" in args[0]:
-            return MockResponse(MOCK_ANTI_FORGERY_RESPONSE, 200, kwargs)
+            return MockResponse(MOCK_ANTI_FORGERY_RESPONSE, 200, MOCK_ANTI_FORGERY_RESPONSE_COOKIES, kwargs)
 
         for pattern, response in routes:
             if pattern in args[0]:
-                return MockResponse(response, 200, kwargs)
+                return MockResponse(response, 200, {}, kwargs)
 
-        return MockResponse("Not Found", 200, kwargs)
+        return MockResponse("Not Found", 200, {}, kwargs)
 
     return mocked_requests_get


### PR DESCRIPTION
This gets the xsrf token value using the xsrf-token cookie instead of the JSON response. Even though SRP's API limits cross-origin requests, this value could still be removed from the response soon.