### PR TITLE
Summarize kwh & cost if total* are zero

### DIFF
--- a/srpenergy/__init__.py
+++ b/srpenergy/__init__.py
@@ -1,2 +1,2 @@
 """Init file for Srp Energy."""
-__version__ = "1.3.5"
+__version__ = "1.3.6"

--- a/srpenergy/client.py
+++ b/srpenergy/client.py
@@ -300,7 +300,24 @@ class SrpEnergyClient:
                 for row in hourly_usage_list:
 
                     total_kwh = row["totalKwh"]
+                    if total_kwh == 0:
+                        "Attempting to build the total_kwh from separate fields"
+                        total_kwh = (
+                            row["onPeakKwh"]
+                            + row["offPeakKwh"]
+                            + row["shoulderKwh"]
+                            + row["superOffPeakKwh"]
+                        )
+
                     total_cost = row["totalCost"]
+                    if total_cost == 0:
+                        "Attempting to build the total_cost from separate fields"
+                        total_cost = (
+                            row["onPeakCost"]
+                            + row["offPeakCost"]
+                            + row["shoulderCost"]
+                            + row["superOffPeakCost"]
+                        )
 
                     # Check if on Time of Use Plan
                     if is_tou:


### PR DESCRIPTION
This change fixes lamoreauxlab/srpenergy-api-client-python#9 by using
the individual rate times to calculate the usage and costs. This is
common for anyone on a plan that isn't Time of Use (TOU) but has
different rates throughout the day, such as EZ-3.